### PR TITLE
Fixing start after reset

### DIFF
--- a/assets/js/components/Play.js
+++ b/assets/js/components/Play.js
@@ -233,6 +233,8 @@ export default class Play {
 
         this.timer && document.getElementById('btn_stop').click();
 
+        delete this.timer.isPlaying;
+
         History.clear();
         Warnings.hide(this.warnings_div);
     }


### PR DESCRIPTION
Ao clicar em play depois de resetar, o primeiro número não era sorteado instantaneamente.